### PR TITLE
Add initial boilerplate for Spark 3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ subprojects {
     pluginManager.withPlugin('com.diffplug.spotless') {
         spotless {
             java {
-                target 'src/main/java/**/*.java', 'src/test/java/**/*.java'
+                target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/integration/java/**/*.java'
                 googleJavaFormat("1.24.0")
                 removeUnusedImports()
                 licenseHeaderFile "$rootDir/.baseline/copyright/copyright-header-java.txt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+systemProp.defaultSparkVersions=3.5
+systemProp.knownSparkVersions=3.5
+systemProp.defaultScalaVersion=2.12
+systemProp.knownScalaVersions=2.12,2.13
+
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.configuration-cache=false
+org.gradle.jvmargs=-Xmx1024m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[versions]
+junit = "5.11.3"
+spark-hive35 = "3.5.2"
+
+[libraries]
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,39 @@
 rootProject.name = 'trinitylake'
 
 include 'core'
+include 'spark'
 
 project(':core').name = 'trinitylake-core'
+project(':spark').name = 'trinitylake-spark'
+
+if (System.getProperty("allModules") != null) {
+    System.setProperty("sparkVersions", System.getProperty("knownSparkVersions"))
+}
+
+List<String> knownSparkVersions = System.getProperty("knownSparkVersions").split(",")
+String sparkVersionsString = System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")
+List<String> sparkVersions = sparkVersionsString != null && !sparkVersionsString.isEmpty() ? sparkVersionsString.split(",") : []
+
+if (!knownSparkVersions.containsAll(sparkVersions)) {
+    throw new GradleException("Found unsupported Spark versions: " + (sparkVersions - knownSparkVersions))
+}
+
+List<String> knownScalaVersions = System.getProperty("knownScalaVersions").split(",")
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+
+if (!knownScalaVersions.contains(scalaVersion)) {
+    throw new GradleException("Found unsupported Scala version: " + scalaVersion)
+}
+
+if (sparkVersions.contains("3.5")) {
+    include ":trinitylake-spark:spark-3.5_${scalaVersion}"
+    include ":trinitylake-spark:spark-extensions-3.5_${scalaVersion}"
+    include ":trinitylake-spark:spark-runtime-3.5_${scalaVersion}"
+    project(":trinitylake-spark:spark-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark')
+    project(":trinitylake-spark:spark-3.5_${scalaVersion}").name = "trinitylake-spark-3.5_${scalaVersion}"
+    project(":trinitylake-spark:spark-extensions-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark-extensions')
+    project(":trinitylake-spark:spark-extensions-3.5_${scalaVersion}").name = "trinitylake-spark-extensions-3.5_${scalaVersion}"
+    project(":trinitylake-spark:spark-runtime-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark-runtime')
+    project(":trinitylake-spark:spark-runtime-3.5_${scalaVersion}").name = "trinitylake-spark-runtime-3.5_${scalaVersion}"
+}
 

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
+
+if (sparkVersions.contains("3.5")) {
+    apply from: file("$projectDir/v3.5/build.gradle")
+}

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+String sparkMajorVersion = '3.5'
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+
+project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}") {
+    apply plugin: 'scala'
+
+    sourceSets {
+        main {
+            scala.srcDirs = ['src/main/scala', 'src/main/java']
+            java.srcDirs = []
+        }
+    }
+
+    dependencies {
+        implementation project(':trinitylake-core')
+
+        compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}")
+
+        testImplementation libs.junit.jupiter
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+}
+
+project(":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
+    apply plugin: 'java-library'
+    apply plugin: 'scala'
+
+    dependencies {
+        implementation project(':trinitylake-core')
+
+        compileOnly "org.scala-lang:scala-library"
+        compileOnly project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
+        compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}")
+
+        testImplementation project(path: ":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
+        testImplementation libs.junit.jupiter
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+}
+
+project(":trinitylake-spark:trinitylake-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
+    apply plugin: 'scala'
+
+    sourceSets {
+        integration {
+            java.srcDir "$projectDir/src/integration/java"
+        }
+    }
+
+    dependencies {
+        implementation project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
+        implementation project(":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+
+        integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}"
+        integrationImplementation libs.junit.jupiter
+        integrationImplementation project(path: ":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
+        integrationImplementation project(path: ":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+
+        integrationCompileOnly project(":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+        integrationCompileOnly project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
+    }
+
+    task integrationTest(type: Test) {
+        useJUnitPlatform()
+        description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
+        group = "verification"
+        jvmArgs += project.property('extraJvmArgs')
+        testClassesDirs = sourceSets.integration.output.classesDirs
+        classpath = sourceSets.integration.runtimeClasspath
+    }
+
+    check.dependsOn integrationTest
+
+    jar {
+        enabled = false
+    }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/io/trinitylake/spark/extensions/TrinityLakeSparkSessionExtensions.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/io/trinitylake/spark/extensions/TrinityLakeSparkSessionExtensions.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trinitylake.spark.extensions
+
+import org.apache.spark.sql.SparkSessionExtensions
+
+class TrinityLakeSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+    override def apply(extensions: SparkSessionExtensions): Unit = {}
+}

--- a/spark/v3.5/spark-extensions/src/test/java/io/trinitylake/spark/extensions/TestTrinityLakeSparkSessionExtensions.java
+++ b/spark/v3.5/spark-extensions/src/test/java/io/trinitylake/spark/extensions/TestTrinityLakeSparkSessionExtensions.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark.extensions;
+
+import org.junit.jupiter.api.Test;
+
+public class TestTrinityLakeSparkSessionExtensions {
+
+  @Test
+  public void test() {}
+}

--- a/spark/v3.5/spark-runtime/src/integration/java/io/trinitylake/spark/SmokeTest.java
+++ b/spark/v3.5/spark-runtime/src/integration/java/io/trinitylake/spark/SmokeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark;
+
+import io.trinitylake.spark.extensions.TrinityLakeSparkSessionExtensions;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class SmokeTest {
+
+  private static SparkSession spark;
+
+  @BeforeAll
+  public static void setup() {
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .appName("SmokeTest")
+            .config("spark.sql.extensions", TrinityLakeSparkSessionExtensions.class.getName())
+            .getOrCreate();
+  }
+
+  @Test
+  public void test() {}
+}

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeCatalog.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeCatalog.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark;
+
+public class TrinityLakeCatalog {}

--- a/spark/v3.5/spark/src/test/java/io/trinitylake/spark/TestTrinityLakeCatalog.java
+++ b/spark/v3.5/spark/src/test/java/io/trinitylake/spark/TestTrinityLakeCatalog.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark;
+
+import org.junit.jupiter.api.Test;
+
+public class TestTrinityLakeCatalog {
+
+    @Test
+    public void test() {}
+}

--- a/spark/v3.5/spark/src/test/java/io/trinitylake/spark/TestTrinityLakeCatalog.java
+++ b/spark/v3.5/spark/src/test/java/io/trinitylake/spark/TestTrinityLakeCatalog.java
@@ -17,6 +17,6 @@ import org.junit.jupiter.api.Test;
 
 public class TestTrinityLakeCatalog {
 
-    @Test
-    public void test() {}
+  @Test
+  public void test() {}
 }


### PR DESCRIPTION
Added basic boiler plate for Spark 3.5 module structure with three submodules per issue #3 
- spark
- spark-extensions
- spark-runtime