### PR TITLE
Add Spark SQL extensions boiler for transaction semantic support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,11 @@
 # limitations under the License.
 
 [versions]
+antlr = "4.9.3"
 junit = "5.11.3"
+scala-collection-compat = "2.12.0"
 spark-hive35 = "3.5.2"
 
 [libraries]
+antlr-antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -27,6 +27,11 @@ project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersio
 
     dependencies {
         implementation project(':trinitylake-core')
+        implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+        if (scalaVersion == '2.12') {
+            // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+            implementation 'org.scala-lang:scala-library:2.12.18'
+        }
 
         compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}")
 
@@ -39,11 +44,30 @@ project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersio
 }
 
 project(":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
+    apply plugin: 'antlr'
     apply plugin: 'java-library'
     apply plugin: 'scala'
 
+    configurations {
+        /*
+         The Gradle Antlr plugin erroneously adds both antlr-build and runtime dependencies to the runtime path. This
+         bug https://github.com/gradle/gradle/issues/820 exists because older versions of Antlr do not have separate
+         runtime and implementation dependencies and they do not want to break backwards compatibility. So to only end up with
+         the runtime dependency on the runtime classpath we remove the dependencies added by the plugin here. Then add
+         the runtime dependency back to only the runtime configuration manually.
+        */
+        implementation {
+            extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+        }
+    }
+
     dependencies {
         implementation project(':trinitylake-core')
+        implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+        if (scalaVersion == '2.12') {
+            // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+            implementation 'org.scala-lang:scala-library:2.12.18'
+        }
 
         compileOnly "org.scala-lang:scala-library"
         compileOnly project(":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
@@ -51,15 +75,21 @@ project(":trinitylake-spark:trinitylake-spark-extensions-${sparkMajorVersion}_${
 
         testImplementation project(path: ":trinitylake-spark:trinitylake-spark-${sparkMajorVersion}_${scalaVersion}")
         testImplementation libs.junit.jupiter
+
+        antlr libs.antlr.antlr4
     }
 
     test {
         useJUnitPlatform()
     }
+
+    generateGrammarSource {
+        maxHeapSize = "64m"
+        arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
+    }
 }
 
 project(":trinitylake-spark:trinitylake-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-    apply plugin: 'scala'
 
     sourceSets {
         integration {

--- a/spark/v3.5/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/TrinityLakeSqlExtensions.g4
+++ b/spark/v3.5/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/TrinityLakeSqlExtensions.g4
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+grammar TrinityLakeSqlExtensions;
+
+singleStatement
+    : statement EOF
+    ;
+
+statement
+    : beginStatement
+    | commitStatement
+    | rollbackStatement
+    ;
+
+beginStatement
+    : BEGIN (TRANSACTION)?
+    ;
+
+commitStatement
+    : COMMIT (TRANSACTION)?
+    ;
+
+rollbackStatement
+    : ROLLBACK (TRANSACTION)?
+    ;
+
+nonReserved
+    : BEGIN | COMMIT | ROLLBACK | TRANSACTION
+    ;
+
+BEGIN: 'BEGIN';
+TRANSACTION: 'TRANSACTION';
+COMMIT: 'COMMIT';
+ROLLBACK: 'ROLLBACK';
+
+SIMPLE_COMMENT
+    : '--' (~[\r\n])* '\r'? '\n'? -> channel(HIDDEN)
+    ;
+
+WS
+    : [ \r\n\t]+ -> channel(HIDDEN)
+    ;
+
+// Catch-all for anything we don't recognize
+UNRECOGNIZED
+    : .
+    ;

--- a/spark/v3.5/spark-extensions/src/main/scala/io/trinitylake/spark/extensions/TrinityLakeSparkSessionExtensions.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/io/trinitylake/spark/extensions/TrinityLakeSparkSessionExtensions.scala
@@ -11,11 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.trinitylake.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSparkSqlExtensionsParser
+import org.apache.spark.sql.execution.datasources.v2.TrinityLakeStrategy
 
 class TrinityLakeSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
-    override def apply(extensions: SparkSessionExtensions): Unit = {}
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+    // parser extensions
+    extensions.injectParser { case (_, parser) => new TrinityLakeSparkSqlExtensionsParser(parser) }
+
+    // planner extensions
+    extensions.injectPlannerStrategy { spark => TrinityLakeStrategy(spark) }
+  }
 }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TrinityLakeSparkSqlExtensionsParser.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TrinityLakeSparkSqlExtensionsParser.scala
@@ -1,0 +1,266 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.CharStream
+import org.antlr.v4.runtime.CodePointCharStream
+import org.antlr.v4.runtime.CommonToken
+import org.antlr.v4.runtime.IntStream
+import org.antlr.v4.runtime.ParserRuleContext
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime.misc.ParseCancellationException
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.VariableSubstitution
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.StructType
+
+import java.util.Locale
+import scala.util.Try
+
+class TrinityLakeSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+
+  import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSparkSqlExtensionsParser._
+
+  private lazy val astBuilder = new TrinityLakeSqlExtensionsAstBuilder(delegate)
+  private lazy val substitutor = {
+    Try(substitutorCtor.newInstance(SQLConf.get))
+      .getOrElse(substitutorCtor.newInstance())
+  }
+
+  /**
+   * Parse a string to a LogicalPlan.
+   */
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
+    if (isTrinityLakeCommand(sqlTextAfterSubstitution)) {
+      parse(sqlTextAfterSubstitution) { parser =>
+        astBuilder.visit(parser.singleStatement())
+      }.asInstanceOf[LogicalPlan]
+    } else {
+      delegate.parsePlan(sqlText)
+    }
+  }
+
+  /**
+   * Parse a string to an Expression.
+   */
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  /**
+   * Parse a string to a TableIdentifier.
+   */
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  /**
+   * Parse a string to a FunctionIdentifier.
+   */
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  /**
+   * Parse a string to a multi-part identifier.
+   */
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  override def parseQuery(sqlText: String): LogicalPlan = {
+    parsePlan(sqlText)
+  }
+
+  /**
+   * Creates StructType for a given SQL string, which is a comma separated list of field
+   * definitions which will preserve the correct Hive metadata.
+   */
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  /**
+   * Parse a string to a DataType.
+   */
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+
+  private def isTrinityLakeCommand(sqlText: String): Boolean = {
+    val normalized = sqlText
+      .toLowerCase(Locale.ROOT)
+      .trim()
+      // Strip simple SQL comments that terminate a line, e.g. comments starting with `--` .
+      .replaceAll("--.*?\\n", " ")
+      // Strip newlines.
+      .replaceAll("\\s+", " ")
+      // Strip comments of the form  /* ... */. This must come after stripping newlines so that
+      // comments that span multiple lines are caught.
+      .replaceAll("/\\*.*?\\*/", " ")
+      // Strip backtick then `system`.`ancestors_of` changes to system.ancestors_of
+      .replaceAll("`", "")
+      .trim()
+
+    normalized.startsWith("begin") ||
+    normalized.startsWith("commit") ||
+    normalized.startsWith("rollback")
+  }
+
+  protected def parse[T](command: String)(toResult: TrinityLakeSqlExtensionsParser => T): T = {
+    val lexer = new TrinityLakeSqlExtensionsLexer(
+      new UpperCaseCharStream(CharStreams.fromString(command)))
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(TrinityLakeParseErrorListener)
+
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser = new TrinityLakeSqlExtensionsParser(tokenStream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(TrinityLakeParseErrorListener)
+
+    try {
+      try {
+        // first, try parsing with potentially faster SLL mode
+        parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
+        toResult(parser)
+      } catch {
+        case _: ParseCancellationException =>
+          // if we fail, parse with LL mode
+          tokenStream.seek(0) // rewind input stream
+          parser.reset()
+
+          // Try Again.
+          parser.getInterpreter.setPredictionMode(PredictionMode.LL)
+          toResult(parser)
+      }
+    } catch {
+      case e: TrinityLakeParseException if e.command.isDefined =>
+        throw e
+      case e: TrinityLakeParseException =>
+        throw e.withCommand(command)
+      case e: AnalysisException =>
+        val position = Origin(e.line, e.startPosition)
+        throw new TrinityLakeParseException(Option(command), e.message, position, position)
+    }
+  }
+}
+
+class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
+  override def consume(): Unit = wrapped.consume()
+  override def getSourceName: String = wrapped.getSourceName
+  override def index(): Int = wrapped.index
+  override def mark(): Int = wrapped.mark
+  override def release(marker: Int): Unit = wrapped.release(marker)
+  override def seek(where: Int): Unit = wrapped.seek(where)
+  override def size(): Int = wrapped.size
+
+  override def getText(interval: Interval): String = wrapped.getText(interval)
+
+  override def LA(i: Int): Int = {
+    val la = wrapped.LA(i)
+    if (la == 0 || la == IntStream.EOF) la
+    else Character.toUpperCase(la)
+  }
+}
+
+case object TrinityLakeParseErrorListener extends BaseErrorListener {
+  override def syntaxError(
+      recognizer: Recognizer[_, _],
+      offendingSymbol: scala.Any,
+      line: Int,
+      charPositionInLine: Int,
+      msg: String,
+      e: RecognitionException): Unit = {
+    val (start, stop) = offendingSymbol match {
+      case token: CommonToken =>
+        val start = Origin(Some(line), Some(token.getCharPositionInLine))
+        val length = token.getStopIndex - token.getStartIndex + 1
+        val stop = Origin(Some(line), Some(token.getCharPositionInLine + length))
+        (start, stop)
+      case _ =>
+        val start = Origin(Some(line), Some(charPositionInLine))
+        (start, start)
+    }
+    throw new TrinityLakeParseException(None, msg, start, stop)
+  }
+}
+
+class TrinityLakeParseException(
+    val command: Option[String],
+    message: String,
+    val start: Origin,
+    val stop: Origin)
+    extends AnalysisException(message, start.line, start.startPosition) {
+
+  def this(message: String, ctx: ParserRuleContext) = {
+    this(
+      Option(TrinityLakeParserUtils.command(ctx)),
+      message,
+      TrinityLakeParserUtils.position(ctx.getStart),
+      TrinityLakeParserUtils.position(ctx.getStop))
+  }
+
+  override def getMessage: String = {
+    val builder = new StringBuilder
+    builder ++= "\n" ++= message
+    start match {
+      case Origin(
+            Some(l),
+            Some(p),
+            Some(startIndex),
+            Some(stopIndex),
+            Some(sqlText),
+            Some(objectType),
+            Some(objectName)) =>
+        builder ++= s"(line $l, pos $p)\n"
+        command.foreach { cmd =>
+          val (above, below) = cmd.split("\n").splitAt(l)
+          builder ++= "\n== SQL ==\n"
+          above.foreach(builder ++= _ += '\n')
+          builder ++= (0 until p).map(_ => "-").mkString("") ++= "^^^\n"
+          below.foreach(builder ++= _ += '\n')
+        }
+      case _ =>
+        command.foreach { cmd =>
+          builder ++= "\n== SQL ==\n" ++= cmd
+        }
+    }
+    builder.toString
+  }
+
+  def withCommand(cmd: String): TrinityLakeParseException = {
+    new TrinityLakeParseException(Option(cmd), message, start, stop)
+  }
+}
+
+object TrinityLakeSparkSqlExtensionsParser {
+  private val substitutorCtor = {
+    Try(classOf[VariableSubstitution].getConstructor(classOf[SQLConf]))
+      .getOrElse(classOf[VariableSubstitution].getConstructor())
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TrinityLakeSqlExtensionsAstBuilder.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/TrinityLakeSqlExtensionsAstBuilder.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.antlr.v4.runtime.ParserRuleContext
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.misc.Interval
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeParserUtils.withOrigin
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSqlExtensionsParser.BeginStatementContext
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSqlExtensionsParser.CommitStatementContext
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSqlExtensionsParser.RollbackStatementContext
+import org.apache.spark.sql.catalyst.parser.extensions.TrinityLakeSqlExtensionsParser.SingleStatementContext
+import org.apache.spark.sql.catalyst.plans.logical.BeginTransactionCommand
+import org.apache.spark.sql.catalyst.plans.logical.CommitTransactionCommand
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.RollbackTransactionCommand
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.trees.Origin
+
+class TrinityLakeSqlExtensionsAstBuilder(delegate: ParserInterface)
+    extends TrinityLakeSqlExtensionsBaseVisitor[AnyRef] {
+
+  override def visitBeginStatement(ctx: BeginStatementContext): LogicalPlan = {
+    BeginTransactionCommand()
+  }
+
+  override def visitCommitStatement(ctx: CommitStatementContext): LogicalPlan = {
+    CommitTransactionCommand()
+  }
+
+  override def visitRollbackStatement(ctx: RollbackStatementContext): LogicalPlan = {
+    RollbackTransactionCommand()
+  }
+
+  override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
+    visit(ctx.statement).asInstanceOf[LogicalPlan]
+  }
+}
+
+object TrinityLakeParserUtils {
+
+  private[sql] def withOrigin[T](ctx: ParserRuleContext)(f: => T): T = {
+    val current = CurrentOrigin.get
+    CurrentOrigin.set(position(ctx.getStart))
+    try {
+      f
+    } finally {
+      CurrentOrigin.set(current)
+    }
+  }
+
+  private[sql] def position(token: Token): Origin = {
+    val opt = Option(token)
+    Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
+  }
+
+  /** Get the command which created the token. */
+  private[sql] def command(ctx: ParserRuleContext): String = {
+    val stream = ctx.getStart.getInputStream
+    stream.getText(Interval.of(0, stream.size() - 1))
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/BeginTransactionCommand.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/BeginTransactionCommand.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class BeginTransactionCommand() extends LeafCommand {
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    "BeginTransaction"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CommitTransactionCommand.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CommitTransactionCommand.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class CommitTransactionCommand() extends LeafCommand {
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    "CommitTransaction"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RollbackTransactionCommand.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RollbackTransactionCommand.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class RollbackTransactionCommand() extends LeafCommand {
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    "RollbackTransaction"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BeginTransactionExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BeginTransactionExec.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class BeginTransactionExec() extends LeafV2CommandExec {
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    Seq.empty
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    "BeginTransactionExec"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CommitTransactionExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CommitTransactionExec.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class CommitTransactionExec() extends LeafV2CommandExec {
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    Seq.empty
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    "CommitTransactionExec"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RollbackTransactionExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RollbackTransactionExec.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class RollbackTransactionExec() extends LeafV2CommandExec {
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    Seq.empty
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    "RollbackTransactionExec"
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TrinityLakeStrategy.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TrinityLakeStrategy.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.plans.logical.BeginTransactionCommand
+import org.apache.spark.sql.catalyst.plans.logical.CommitTransactionCommand
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.RollbackTransactionCommand
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.{SparkSession, Strategy}
+
+case class TrinityLakeStrategy(spark: SparkSession) extends Strategy {
+
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case BeginTransactionCommand() =>
+      BeginTransactionExec() :: Nil
+    case CommitTransactionCommand() =>
+      CommitTransactionExec() :: Nil
+    case RollbackTransactionCommand() =>
+      RollbackTransactionExec() :: Nil
+    case _ => Nil
+  }
+}


### PR DESCRIPTION
Added the initial support of transaction semantics and integration with Spark SQL extensions for #4. 

Introduces ANTLR4 grammar foundation for transaction commands:
- `BEGIN [TRANSACTION]`
- `COMMIT [TRANSACTION]`
- `ROLLBACK [TRANSACTION]`

Also adds Spark SQL parser features:
- Enhanced error handling with position tracking
- Support for SQL comments and whitespace handling
