### PR TITLE
Add initial Spark Catalog with Lakehouse support

### DIFF
--- a/core/src/main/java/io/trinitylake/TransactionContext.java
+++ b/core/src/main/java/io/trinitylake/TransactionContext.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.execution.datasources.v2
+package io.trinitylake;
 
-import io.trinitylake.spark.SparkCatalog
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Attribute
+public class TransactionContext {
+  private final String transactionId;
+  private final BasicLakehouseVersion version;
 
-case class CommitTransactionExec(sparkCatalog: SparkCatalog) extends LeafV2CommandExec {
-
-  override lazy val output: Seq[Attribute] = Nil
-
-  override protected def run(): Seq[InternalRow] = {
-    sparkCatalog.commitTransaction()
-    Seq.empty
+  public TransactionContext(String transactionId, BasicLakehouseVersion version) {
+    this.transactionId = transactionId;
+    this.version = version;
   }
 
-  override def simpleString(maxFields: Int): String = {
-    "CommitTransactionExec"
+  public String transactionId() {
+    return transactionId;
+  }
+
+  public BasicLakehouseVersion version() {
+    return version;
   }
 }

--- a/core/src/main/java/io/trinitylake/exception/NoActiveTransactionException.java
+++ b/core/src/main/java/io/trinitylake/exception/NoActiveTransactionException.java
@@ -11,6 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trinitylake.spark;
+package io.trinitylake.exception;
 
-public class TrinityLakeCatalog {}
+public class NoActiveTransactionException extends TrinityLakeRuntimeException {
+
+  public NoActiveTransactionException(Throwable cause, String message, Object... args) {
+    super(cause, message, args);
+  }
+
+  public NoActiveTransactionException(String message, Object... args) {
+    super(message, args);
+  }
+}

--- a/core/src/main/java/io/trinitylake/exception/TransactionAlreadyExistsException.java
+++ b/core/src/main/java/io/trinitylake/exception/TransactionAlreadyExistsException.java
@@ -11,22 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.execution.datasources.v2
+package io.trinitylake.exception;
 
-import io.trinitylake.spark.SparkCatalog
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Attribute
+public class TransactionAlreadyExistsException extends TrinityLakeRuntimeException {
 
-case class CommitTransactionExec(sparkCatalog: SparkCatalog) extends LeafV2CommandExec {
-
-  override lazy val output: Seq[Attribute] = Nil
-
-  override protected def run(): Seq[InternalRow] = {
-    sparkCatalog.commitTransaction()
-    Seq.empty
+  public TransactionAlreadyExistsException(Throwable cause, String message, Object... args) {
+    super(cause, message, args);
   }
 
-  override def simpleString(maxFields: Int): String = {
-    "CommitTransactionExec"
+  public TransactionAlreadyExistsException(String message, Object... args) {
+    super(message, args);
   }
 }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BeginTransactionExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BeginTransactionExec.scala
@@ -13,14 +13,16 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
+import io.trinitylake.spark.SparkCatalog
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 
-case class BeginTransactionExec() extends LeafV2CommandExec {
+case class BeginTransactionExec(sparkCatalog: SparkCatalog) extends LeafV2CommandExec {
 
   override lazy val output: Seq[Attribute] = Nil
 
   override protected def run(): Seq[InternalRow] = {
+    sparkCatalog.beginTransaction()
     Seq.empty
   }
 

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RollbackTransactionExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RollbackTransactionExec.scala
@@ -13,14 +13,16 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
+import io.trinitylake.spark.SparkCatalog
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 
-case class RollbackTransactionExec() extends LeafV2CommandExec {
+case class RollbackTransactionExec(sparkCatalog: SparkCatalog) extends LeafV2CommandExec {
 
   override lazy val output: Seq[Attribute] = Nil
 
   override protected def run(): Seq[InternalRow] = {
+    sparkCatalog.rollbackTransaction()
     Seq.empty
   }
 

--- a/spark/v3.5/spark-runtime/src/integration/java/io/trinitylake/spark/SmokeTest.java
+++ b/spark/v3.5/spark-runtime/src/integration/java/io/trinitylake/spark/SmokeTest.java
@@ -29,6 +29,8 @@ public class SmokeTest {
             .master("local[2]")
             .appName("SmokeTest")
             .config("spark.sql.extensions", TrinityLakeSparkSessionExtensions.class.getName())
+            .config("spark.sql.catalog.my_catalog", SparkCatalog.class.getName())
+            .config("spark.sql.defaultCatalog", "my_catalog")
             .getOrCreate();
   }
 

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/SparkCatalog.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark;
+
+import io.trinitylake.BasicLakehouseVersion;
+import io.trinitylake.Lakehouse;
+import io.trinitylake.TransactionContext;
+import io.trinitylake.exception.NoActiveTransactionException;
+import io.trinitylake.exception.TransactionAlreadyExistsException;
+import io.trinitylake.spark.source.HasLakeHouse;
+import io.trinitylake.spark.source.SupportsTransactions;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.analysis.*;
+import org.apache.spark.sql.connector.catalog.*;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class SparkCatalog implements HasLakeHouse, SupportsNamespaces, SupportsTransactions {
+  private String catalogName = null;
+  private Lakehouse lakeHouse = null;
+  private final ThreadLocal<TransactionContext> currentTransaction = new ThreadLocal<>();
+
+  @Override
+  public void initialize(String catalogName, CaseInsensitiveStringMap options) {
+    this.catalogName = catalogName;
+    this.lakeHouse = null;
+  }
+
+  @Override
+  public String name() {
+    return catalogName;
+  }
+
+  @Override
+  public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
+    return new Identifier[0];
+  }
+
+  @Override
+  public Table loadTable(Identifier ident) throws NoSuchTableException {
+    return null;
+  }
+
+  @Override
+  public Table createTable(
+      Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return null;
+  }
+
+  @Override
+  public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
+    return null;
+  }
+
+  @Override
+  public boolean dropTable(Identifier ident) {
+    return false;
+  }
+
+  @Override
+  public void renameTable(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchTableException, TableAlreadyExistsException {}
+
+  @Override
+  public String[][] listNamespaces() throws NoSuchNamespaceException {
+    return new String[0][];
+  }
+
+  @Override
+  public String[][] listNamespaces(String[] namespace) throws NoSuchNamespaceException {
+    return new String[0][];
+  }
+
+  @Override
+  public Map<String, String> loadNamespaceMetadata(String[] namespace)
+      throws NoSuchNamespaceException {
+    return new HashMap<>();
+  }
+
+  @Override
+  public void createNamespace(String[] namespace, Map<String, String> metadata)
+      throws NamespaceAlreadyExistsException {}
+
+  @Override
+  public void alterNamespace(String[] namespace, NamespaceChange... changes)
+      throws NoSuchNamespaceException {}
+
+  @Override
+  public boolean dropNamespace(String[] namespace, boolean cascade)
+      throws NoSuchNamespaceException, NonEmptyNamespaceException {
+    return false;
+  }
+
+  @Override
+  public void beginTransaction() {
+    if (hasActiveTransaction()) {
+      throw new TransactionAlreadyExistsException("Transaction already active in this session.");
+    }
+    String txnId = generateTransactionId();
+    BasicLakehouseVersion version = lakeHouse.beginTransaction(txnId);
+    currentTransaction.set(new TransactionContext(txnId, version));
+  }
+
+  @Override
+  public void commitTransaction() {
+    ensureActiveTransaction();
+    TransactionContext ctx = currentTransaction.get();
+    try {
+      lakeHouse.commitTransaction(ctx.transactionId(), ctx.version());
+    } finally {
+      currentTransaction.remove();
+    }
+  }
+
+  @Override
+  public void rollbackTransaction() {
+    ensureActiveTransaction();
+    TransactionContext ctx = currentTransaction.get();
+    try {
+      lakeHouse.rollbackTransaction(ctx.transactionId());
+    } finally {
+      currentTransaction.remove();
+    }
+  }
+
+  @Override
+  public boolean hasActiveTransaction() {
+    return currentTransaction.get() != null;
+  }
+
+  @Override
+  public Lakehouse lakeHouse() {
+    return lakeHouse;
+  }
+
+  private String generateTransactionId() {
+    return String.valueOf(System.currentTimeMillis());
+  }
+
+  private void ensureActiveTransaction() {
+    if (!hasActiveTransaction()) {
+      throw new NoActiveTransactionException("No active transaction");
+    }
+  }
+}

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/source/HasLakeHouse.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/source/HasLakeHouse.java
@@ -11,22 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.execution.datasources.v2
+package io.trinitylake.spark.source;
 
-import io.trinitylake.spark.SparkCatalog
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import io.trinitylake.Lakehouse;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
-case class CommitTransactionExec(sparkCatalog: SparkCatalog) extends LeafV2CommandExec {
+public interface HasLakeHouse extends TableCatalog {
 
-  override lazy val output: Seq[Attribute] = Nil
-
-  override protected def run(): Seq[InternalRow] = {
-    sparkCatalog.commitTransaction()
-    Seq.empty
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    "CommitTransactionExec"
-  }
+  /** Returns the underlying {@link io.trinitylake.Lakehouse} backing this Spark Catalog */
+  Lakehouse lakeHouse();
 }

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/source/SupportsTransactions.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/source/SupportsTransactions.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.spark.source;
+
+import io.trinitylake.exception.CommitFailureException;
+import io.trinitylake.exception.NoActiveTransactionException;
+import io.trinitylake.exception.TransactionAlreadyExistsException;
+
+public interface SupportsTransactions {
+
+  /**
+   * Begin a new transaction.
+   *
+   * <p>This operation will fail if there is already an active transaction in the current session. A
+   * transaction must be started before performing any transactional operations.
+   *
+   * @throws TransactionAlreadyExistsException if a transaction is already active
+   */
+  void beginTransaction();
+
+  /**
+   * Commit the current transaction.
+   *
+   * <p>This operation persists all changes made during the transaction and makes them visible to
+   * other sessions. The transaction must be active when committing.
+   *
+   * @throws NoActiveTransactionException if no transaction is active
+   * @throws CommitFailureException if the commit operation fails
+   */
+  void commitTransaction();
+
+  /**
+   * Rollback the current transaction.
+   *
+   * <p>This operation discards all changes made during the transaction and releases any locks. The
+   * transaction must be active when rolling back.
+   *
+   * @throws NoActiveTransactionException if no transaction is active
+   */
+  void rollbackTransaction();
+
+  /**
+   * Check if there is currently an active transaction in this session.
+   *
+   * @return true if there is an active transaction, false otherwise
+   */
+  boolean hasActiveTransaction();
+}


### PR DESCRIPTION
This PR lays down the foundation for the TrinityLake Spark Catalog #20 and integrates it with the underlying TrinityLake transaction functionalities. For now, it focuses on scenarios involving thread-locked transactions within a Spark session. In other words, if the user is in a transaction, the system stores a snapshot of the `Lakehouse` and uses it for all Spark interactions until the transaction is committed.

Currently, the transaction logic is on the spark side but eventually the transaction initiation logic should be in the core module




