### PR TITLE
fix be-tree split logic, and serialization

### DIFF
--- a/pytrinity/poetry.lock
+++ b/pytrinity/poetry.lock
@@ -67,10 +67,22 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -125,6 +137,22 @@ files = [
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
 type = ["mypy (>=1.11.2)"]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
@@ -202,7 +230,28 @@ files = [
 [package.extras]
 test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
+[[package]]
+name = "pytest"
+version = "8.3.4"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "64c853adc292f5e2f1d94a4a6ea4e67e021112a027d0a8110a2b79e8814a115e"
+content-hash = "5570ed1b23c213feef2b8a0209369b816bee0e08f14ec120167956d811fe9903"

--- a/pytrinity/pyproject.toml
+++ b/pytrinity/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pytrinity"
+name = "trinitylake"
 version = "0.1.0"
 description = ""
 authors = []
@@ -8,7 +8,8 @@ requires-python = ">=3.13"
 dependencies = [
     "pyarrow (>=19.0.0,<20.0.0)",
     "protobuf (>=5.29.3,<6.0.0)",
-    "black (>=24.10.0,<25.0.0)"
+    "black (>=24.10.0,<25.0.0)",
+    "pytest (>=8.3.4,<9.0.0)"
 ]
 
 

--- a/pytrinity/pytrinity/lakehouse_version.py
+++ b/pytrinity/pytrinity/lakehouse_version.py
@@ -11,7 +11,7 @@ from pytrinity.const import (
 from pytrinity.object_key_encoder import ObjectKeyEncoder
 from pytrinity.protobuf.Definitions_pb2 import NamespaceDef, TableDef, LakehouseDef
 from pytrinity.storage import Storage
-from tree.trinity_tree import TrinityNode, TrinityTree
+from pytrinity.tree import TrinityNode, TrinityTree
 
 
 class LakehouseVersion:

--- a/pytrinity/pytrinity/tree/__init__.py
+++ b/pytrinity/pytrinity/tree/__init__.py
@@ -1,0 +1,1 @@
+from pytrinity.tree.trinity_tree import TrinityTree, TrinityNode

--- a/pytrinity/pytrinity/tree/trinity_tree.py
+++ b/pytrinity/pytrinity/tree/trinity_tree.py
@@ -1,30 +1,38 @@
-from bisect import bisect_left
+from bisect import bisect_left, bisect_right
+from collections import defaultdict
+from typing import Optional, List
 
 
 class TrinityNode:
-    def __init__(self):
+    def __init__(
+        self, parent: Optional["TrinityNode"] = None, is_leaf_node: bool = True
+    ):
         self.system_rows = []
         self.buffer = []
         self.rows = []
         self.children = []
+        self.parent = parent
+        self.is_leaf_node = is_leaf_node
 
     def is_leaf(self):
-        return len(self.children) == 0
+        return self.is_leaf_node or len(self.children) == 0
 
 
 class TrinityTree:
-    def __init__(self, root_node: TrinityNode = None, degree=400, buffer_size=300):
+    def __init__(
+        self, root_node: TrinityNode = None, order: int = 400, buffer_size: int = 300
+    ):
         self.root = root_node
-        self.degree = degree
+        self.order = order
         self.buffer_size = buffer_size
 
     def get(self, key: str):
         return self._search(self.root, key)
 
-    def insert(self, key: str, value):
+    def insert(self, key: str, value: Optional[str]):
         self.root.buffer.append((key, value))
 
-        if self._is_buffer_full(self.root):
+        if self._should_flush_buffer(self.root):
             self._flush_buffer(self.root)
 
     def delete(self, key: str):
@@ -32,71 +40,120 @@ class TrinityTree:
             self.get(key)
         except:
             raise KeyError(f"Key {key} not found")
-        self.insert(key, None)
+        self.insert(key, None)  # tombstone
 
     def range_query(self, start: str, end: str):
-        result = []
+        result = {}
         self._range_query_helper(self.root, start, end, result)
-        return result
+        return [(k, v) for k, v in result.items() if v]
 
-    def _search(self, node: TrinityNode, key):
+    def _search(self, node: TrinityNode, search_key: str) -> Optional[str]:
+        if not node:
+            return
+
         # first check the buffer in order of most recent to oldest
-        for k, v in reversed(node.buffer):
-            if k == key:
-                if v is None:
+        for key, val in reversed(node.buffer):
+            if search_key == key:
+                if val is None:
                     raise KeyError(f"Key {key} not found")
-                return v
+                return val
 
         # then check the keys in the node
-        for k, v in node.rows:
-            if k == key:
-                return v
+        idx = bisect_left([k for k, _ in node.rows], search_key)
+        if idx < len(node.rows) and node.rows[idx][0] == search_key:
+            return node.rows[idx][1]
 
-        if not node.is_leaf:
-            # TODO: find correct child
-            return self._search(node.children[0], key)
-        raise KeyError(f"Key {key} not found")
+        # no more children to search
+        if node.is_leaf():
+            raise KeyError(f"Key {search_key} not found")
 
-    def _is_buffer_full(self, node: TrinityNode):
+        child_idx = bisect_right([k for k, _ in node.rows], search_key)
+        return self._search(node.children[child_idx], search_key)
+
+    def _should_flush_buffer(self, node: TrinityNode):
         return len(node.buffer) > self.buffer_size
 
     def _flush_buffer(self, node: TrinityNode):
         if node.is_leaf():
-            self._merge_buffer_into_rows(node)
+            self._flush_leaf_node(node)
         else:
-            for k, v in node.buffer:
-                child_idx = bisect_left(node.children, k)
-                node.children[child_idx].buffer.append((k, v))
-            node.buffer.clear()
+            self._flush_internal_node(node)
 
-            for child in node.children:
-                if self._is_buffer_full(child):
-                    self._flush_buffer(child)
+        if len(node.rows) > self.order:
+            self._split_node(node)
 
-    def _merge_buffer_into_rows(self, node: TrinityNode):
-        seen = {}
-        # left to right because latest will overwrite
+    def _flush_leaf_node(self, node: TrinityNode) -> None:
+        # first populate persisted rows
+        merged_rows = {key: value for key, value in node.rows}
+
+        # apply pending updates
         for key, value in node.buffer:
-            seen[key] = value
+            if not value:
+                merged_rows.pop(key)  # delete
+            else:
+                merged_rows[key] = value  # insert/update
 
-        for key, value in node.rows:
-            if key not in seen:
-                seen[key] = value
-        node.rows = sorted([(k, v) for k, v in seen.items()])
+        node.rows = sorted(merged_rows.items())
+        node.children = [None] * (len(node.rows) + 1)
         node.buffer.clear()
-        return node
 
-    def _split_node(self):
-        pass
+    def _flush_internal_node(self, node):
+        row_keys = [k for k, _ in node.rows]
+        flush_map = defaultdict(list)
+
+        # group messages by child nodes
+        for key, value in node.buffer:
+            child_idx = bisect_right(row_keys, key)
+            flush_map[child_idx].append((key, value))
+
+        # flush message batch to child nodes
+        for idx, message in flush_map.items():
+            child_node = node.children[idx]
+            for key, value in message:
+                child_node.buffer.append((key, value))
+            if self._should_flush_buffer(child_node):
+                self._flush_buffer(child_node)
+        node.buffer.clear()
+
+    def _split_node(self, node):
+        split_idx = len(node.rows) // 2
+        mid_key, mid_value = node.rows[split_idx]
+
+        left = TrinityNode(parent=node)
+        right = TrinityNode(parent=node)
+
+        left.rows = node.rows[:split_idx]
+        right.rows = node.rows[split_idx + 1 :]
+
+        if not node.is_leaf():
+            left.children = node.children[: split_idx + 1]
+            right.children = node.children[split_idx + 1 :]
+
+        else:
+            left.children = [None] * (len(left.rows) + 1)
+            right.children = [None] * (len(right.rows) + 1)
+
+        if node == self.root:
+            new_root = TrinityNode(is_leaf_node=False)
+            new_root.rows = [(mid_key, mid_value)]
+            new_root.children = [left, right]
+            self.root = new_root
+        else:
+            # insert mid into parent
+            parent = node.parent
+            idx = bisect_left([k for k, _ in parent.rows], mid_key)
+            parent.rows.insert(idx, (mid_key, mid_value))
+            parent.children[idx] = left
+            parent.children.insert(idx + 1, right)
 
     def _range_query_helper(self, node: TrinityNode, start: str, end: str, result):
-        for key, value in node.buffer:
-            if start <= key <= end and value is not None:
-                result.append((key, value))
+        for key, value in reversed(node.buffer):
+            if start <= key <= end and key not in result:
+                result[key] = value
 
         for key, value in node.rows:
-            if start <= key <= end:
-                result.append((key, value))
+            if start <= key <= end and key not in result:
+                result[key] = value
 
         if not node.is_leaf():
             start_idx = bisect_left([k for k, _ in node.rows], start)

--- a/pytrinity/tests/tree/test_trinity_tree.py
+++ b/pytrinity/tests/tree/test_trinity_tree.py
@@ -1,0 +1,58 @@
+import pytest
+from tree import TrinityTree, TrinityNode
+
+
+@pytest.fixture
+def empty_tree():
+    return TrinityTree(root_node=TrinityNode(), order=3, buffer_size=2)
+
+
+def test_basic_get_with_insert_and_update(empty_tree):
+    empty_tree.insert("a", "a")
+    empty_tree.insert("b", "b")
+
+    assert empty_tree.get("a") == "a"
+    assert empty_tree.get("b") == "b"
+
+    # Test update
+    empty_tree.insert("a", "a-updated")
+    assert empty_tree.get("a") == "a-updated"
+
+
+def test_basic_delete(empty_tree):
+    empty_tree.insert("a", "a")
+    empty_tree.delete("a")
+
+    with pytest.raises(KeyError):
+        empty_tree.get("a")
+
+
+def test_range_query(empty_tree):
+    data = ["a", "b", "c", "d"]
+    for char in data:
+        empty_tree.insert(char, char)
+
+    results = empty_tree.range_query("a", "c")
+    assert set(results) == {("a", "a"), ("b", "b"), ("c", "c")}
+
+    empty_tree.delete("b")
+    results = empty_tree.range_query("a", "c")
+    assert set(results) == {("a", "a"), ("c", "c")}
+
+
+def test_buffer_flushing(empty_tree):
+    empty_tree.insert("a", "1")
+    empty_tree.insert("b", "2")
+    assert len(empty_tree.root.buffer) == 2
+
+    empty_tree.insert("c", "3")
+    assert len(empty_tree.root.buffer) == 0
+    assert len(empty_tree.root.rows) == 3
+
+
+def test_large_insertion(empty_tree):
+    for i in range(100):
+        empty_tree.insert(str(i), str(i))
+
+    for i in range(100):
+        assert empty_tree.get(str(i)) == str(i)


### PR DESCRIPTION
Update the be-tree logic to split properly. Added some additional tests to ensure the root node splits once buffer is flushed.  For now we flush everything but, In the future we can add more granularity to the flushing to ensure we flush a "proper" amount. 