### PR TITLE
refactor: update ipc sufix to arrow all over the application

### DIFF
--- a/core/src/main/java/io/trinitylake/FileLocations.java
+++ b/core/src/main/java/io/trinitylake/FileLocations.java
@@ -27,9 +27,9 @@ public class FileLocations {
   public static final String LAKEHOUSE_DEF_FILE_PATH_PREFIX = "_lakehouse_def_";
   public static final String PROTOBUF_BINARY_FILE_SUFFIX = ".binpb";
 
-  // underscore + 64 binary bits + .ipc suffix
+  // underscore + 64 binary bits + .arrow suffix
   private static final int ROOT_NODE_FILE_PATH_LENGTH = 69;
-  private static final Pattern ROOT_NODE_FILE_PATH_PATTERN = Pattern.compile("^_[01]{64}\\.ipc$");
+  private static final Pattern ROOT_NODE_FILE_PATH_PATTERN = Pattern.compile("^_[01]{64}\\.arrow$");
 
   private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
   // Length of entropy generated in the file path

--- a/core/src/test/java/io/trinitylake/TestFileLocations.java
+++ b/core/src/test/java/io/trinitylake/TestFileLocations.java
@@ -22,13 +22,13 @@ public class TestFileLocations {
   @Test
   public void testVersionToRootNodeFilePath() {
     Assertions.assertThat(FileLocations.rootNodeFilePath(1))
-        .isEqualTo("_1000000000000000000000000000000000000000000000000000000000000000.ipc");
+        .isEqualTo("_1000000000000000000000000000000000000000000000000000000000000000.arrow");
 
     Assertions.assertThat(FileLocations.rootNodeFilePath(12345678))
-        .isEqualTo("_0111001010000110001111010000000000000000000000000000000000000000.ipc");
+        .isEqualTo("_0111001010000110001111010000000000000000000000000000000000000000.arrow");
 
     Assertions.assertThat(FileLocations.rootNodeFilePath(9223372036854775802L))
-        .isEqualTo("_0101111111111111111111111111111111111111111111111111111111111110.ipc");
+        .isEqualTo("_0101111111111111111111111111111111111111111111111111111111111110.arrow");
 
     Assertions.assertThatThrownBy(() -> FileLocations.rootNodeFilePath(-1))
         .isInstanceOf(InvalidArgumentException.class)
@@ -39,17 +39,17 @@ public class TestFileLocations {
   public void testRootNodeFilePathToVersion() {
     Assertions.assertThat(
             FileLocations.versionFromNodeFilePath(
-                "_1000000000000000000000000000000000000000000000000000000000000000.ipc"))
+                "_1000000000000000000000000000000000000000000000000000000000000000.arrow"))
         .isEqualTo(1);
 
     Assertions.assertThat(
             FileLocations.versionFromNodeFilePath(
-                "_0111001010000110001111010000000000000000000000000000000000000000.ipc"))
+                "_0111001010000110001111010000000000000000000000000000000000000000.arrow"))
         .isEqualTo(12345678);
 
     Assertions.assertThat(
             FileLocations.versionFromNodeFilePath(
-                "_0101111111111111111111111111111111111111111111111111111111111110.ipc"))
+                "_0101111111111111111111111111111111111111111111111111111111111110.arrow"))
         .isEqualTo(9223372036854775802L);
 
     Assertions.assertThat(FileLocations.isRootNodeFilePath("invalid.txt")).isFalse();
@@ -59,12 +59,12 @@ public class TestFileLocations {
 
     Assertions.assertThat(
             FileLocations.isRootNodeFilePath(
-                "_2000000000000000000000000000000000000000000000000000000000000000.ipc"))
+                "_2000000000000000000000000000000000000000000000000000000000000000.arrow"))
         .isFalse();
     Assertions.assertThatThrownBy(
             () ->
                 FileLocations.versionFromNodeFilePath(
-                    "_2000000000000000000000000000000000000000000000000000000000000000.ipc"))
+                    "_2000000000000000000000000000000000000000000000000000000000000000.arrow"))
         .isInstanceOf(InvalidArgumentException.class)
         .hasMessageContaining("Root node file path must match pattern");
   }

--- a/core/src/test/java/io/trinitylake/tree/TestTreeOperations.java
+++ b/core/src/test/java/io/trinitylake/tree/TestTreeOperations.java
@@ -41,12 +41,12 @@ public class TestTreeOperations {
     treeRoot.setRollbackFromRootNodeFilePath("some/path/to/rollback/from/root");
     treeRoot.setLakehouseDefFilePath("some/path/to/lakehouse/def");
 
-    File file = tempDir.resolve("testWriteReadRootNodeFile.ipc").toFile();
+    File file = tempDir.resolve("testWriteReadRootNodeFile.arrow").toFile();
 
-    TreeOperations.writeRootNodeFile(storage, "testWriteReadRootNodeFile.ipc", treeRoot);
+    TreeOperations.writeRootNodeFile(storage, "testWriteReadRootNodeFile.arrow", treeRoot);
     Assertions.assertThat(file.exists()).isTrue();
 
-    TreeRoot root = TreeOperations.readRootNodeFile(storage, "testWriteReadRootNodeFile.ipc");
+    TreeRoot root = TreeOperations.readRootNodeFile(storage, "testWriteReadRootNodeFile.arrow");
     Assertions.assertThat(
             treeRoot.nodeKeyTable().stream()
                 .collect(Collectors.toMap(NodeKeyTableRow::key, NodeKeyTableRow::value)))

--- a/docs/format/storage-location.md
+++ b/docs/format/storage-location.md
@@ -67,9 +67,9 @@ For example, an original file path `my/path/my-table-definition.binpb` will be t
 
 ### Non-Root Node File Path
 
-Non-root node file paths are in the form of prefix `node-` plus a version 4 UUID with suffix `.ipc`.
+Non-root node file paths are in the form of prefix `node-` plus a version 4 UUID with suffix `.arrow`.
 For example, if a UUID `6fcb514b-b878-4c9d-95b7-8dc3a7ce6fd8` is generated for the node file,
-the original file name of the node file will be `node-6fcb514b-b878-4c9d-95b7-8dc3a7ce6fd8.ipc`,
+the original file name of the node file will be `node-6fcb514b-b878-4c9d-95b7-8dc3a7ce6fd8.arrow`,
 and that further goes through the [file name optimization](./storage-location#optimized-file-name)
 to produce the final node file path.
 
@@ -91,9 +91,9 @@ With CoW, the root node file name is important because every change to the tree 
 and the root node file name can be used essentially as the version of the tree.
 
 TrinityLake defines that each root node has a numeric version number,
-and the root node is stored in a file name `_<version_number_binary_reversed>.ipc`.
+and the root node is stored in a file name `_<version_number_binary_reversed>.arrow`.
 The file name is persisted in storage as is without [optimization](./storage-location#optimized-file-name).
-For example, the 100th version of the root node file would be stored with name `_00100110000000000000000000000000.ipc`.
+For example, the 100th version of the root node file would be stored with name `_00100110000000000000000000000000.arrow`.
 
 ### Root Node Latest Version Hint File Path
 

--- a/python/trinitylake/const.py
+++ b/python/trinitylake/const.py
@@ -22,7 +22,7 @@ PROTO_BINARY_FILE_SUFFIX = ".binpb"
 
 LAKEHOUSE_DEF_FILE_PREFIX = "_lakehouse_def_"
 
-IPC_FILE_SUFFIX = ".ipc"
+IPC_FILE_SUFFIX = ".arrow"
 
 SCHEMA_ID_PART_SIZE = 4
 

--- a/python/trinitylake/storage/storage.py
+++ b/python/trinitylake/storage/storage.py
@@ -40,7 +40,7 @@ class Storage:
 
     def serialize_protobuf(self, proto_msg, file_name=None) -> str:
         if not file_name:
-            file_name = f"{str(uuid.uuid4())}.ipc"
+            file_name = f"{str(uuid.uuid4())}.arrow"
         serialized_data = proto_msg.SerializeToString()
         file_path = self._full_path(file_name)
         with open(file_path, "wb") as f:
@@ -76,7 +76,7 @@ class Storage:
             if i < len(node.children):
                 child = node.children[i]
                 if child:
-                    child_file_path = f"{str(uuid.uuid4())}.ipc"
+                    child_file_path = f"{str(uuid.uuid4())}.arrow"
                     self.serialize_tree(child, child_file_path)
                     pnodes.append(child_file_path)
                 else:


### PR DESCRIPTION
- Replaced sufix on TestFileLocations and TestTreeOperations
- Replaced on FileLocations
- Replaced on const, storage python modules
- Replaced on README