### PR TITLE
[Build] Add support for Java 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For more details about the format specification, and how to get started and use 
 please visit [trinitylake.io](https://trinitylake.io).
 
 ## Building
+TrinityLake is built using Gradle with Java 11, 17, 21, or 23.
 
 * Build and run tests: `./gradlew build`
 * Build without running tests: `./gradlew build -x test -x integrationTest`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For more details about the format specification, and how to get started and use 
 please visit [trinitylake.io](https://trinitylake.io).
 
 ## Building
+
 TrinityLake is built using Gradle with Java 11, 17, 21, or 23.
 
 * Build and run tests: `./gradlew build`

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 if (JavaVersion.current() == JavaVersion.VERSION_11) {
     project.ext.jdkVersion = '11'
     project.ext.extraJvmArgs = []
-} else if (JavaVersion.current() == JavaVersion.VERSION_17 || JavaVersion.current() == JavaVersion.VERSION_21) {
+} else if (JavaVersion.current() == JavaVersion.VERSION_17 || JavaVersion.current() == JavaVersion.VERSION_21 || JavaVersion.current() == JavaVersion.VERSION_23) {
     project.ext.jdkVersion = JavaVersion.current().getMajorVersion().toString()
     project.ext.extraJvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED",
                                 "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
@@ -47,7 +47,7 @@ if (JavaVersion.current() == JavaVersion.VERSION_11) {
                                 "--add-opens", "java.base/sun.util.calendar=ALL-UNNAMED",
                                 "--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
 } else {
-    throw new GradleException("This build must be run with JDK 11 or 17 or 21 but was executed with JDK " + JavaVersion.current())
+    throw new GradleException("This build must be run with JDK 11, 17, 21, or 23 but was executed with JDK " + JavaVersion.current())
 }
 
 allprojects {
@@ -99,7 +99,12 @@ subprojects {
 
     test {
         useJUnitPlatform()
-        jvmArgs '--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED'
+        def args = ['--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED']
+        // Workaround for SecurityManager deprecation in JDK23
+        if (JavaVersion.current() == JavaVersion.VERSION_23) {
+            args.add('-Djava.security.manager=allow')
+        }
+        jvmArgs args
     }
 
     dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description
* Update gradle version to 8.10.0, which is the earliest version that support java 23. https://docs.gradle.org/8.10/release-notes.html
* Add conditional workaround to apply ```-Djava.security.manager=allow``` when JDK 23 due to SecurityManager deprecation.

### Testing
* Built with Java 8. Expected failures
```
* What went wrong:
A problem occurred configuring root project 'trinitylake'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve com.diffplug.spotless:spotless-plugin-gradle:6.25.0.
     Required by:
         project : > com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.25.0
      > Dependency requires at least JVM runtime version 11. This build uses a Java 8 JVM.
```
* Built passed with Java 11, 17, 21, and 23

Closes #40
