### PR TITLE
Standardize drop namespace behavior

### DIFF
--- a/core/src/main/java/io/trinitylake/DropNamespaceBehavior.java
+++ b/core/src/main/java/io/trinitylake/DropNamespaceBehavior.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake;
+
+/** Enum of supported behaviors for dropping a namespace. */
+public enum DropNamespaceBehavior {
+  CASCADE,
+  RESTRICT
+}

--- a/core/src/main/java/io/trinitylake/TrinityLake.java
+++ b/core/src/main/java/io/trinitylake/TrinityLake.java
@@ -208,7 +208,10 @@ public class TrinityLake {
   }
 
   public static RunningTransaction dropNamespace(
-      LakehouseStorage storage, RunningTransaction transaction, String namespaceName, boolean cascade)
+      LakehouseStorage storage,
+      RunningTransaction transaction,
+      String namespaceName,
+      boolean cascade)
       throws ObjectNotFoundException, CommitFailureException {
     LakehouseDef lakehouseDef = TreeOperations.findLakehouseDef(storage, transaction.runningRoot());
     String namespaceKey = ObjectKeys.namespaceKey(namespaceName, lakehouseDef);

--- a/core/src/main/java/io/trinitylake/exception/NonEmptyNamespaceException.java
+++ b/core/src/main/java/io/trinitylake/exception/NonEmptyNamespaceException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trinitylake.exception;
+
+public class NonEmptyNamespaceException extends TrinityLakeRuntimeException {
+
+  public NonEmptyNamespaceException(Throwable cause) {
+    super(cause);
+  }
+
+  public NonEmptyNamespaceException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  public NonEmptyNamespaceException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
+++ b/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
@@ -301,7 +301,8 @@ public class TrinityLakeIcebergCatalog implements Catalog, SupportsNamespaces {
     RunningTransaction transaction = beginOrLoadTransaction(parseResult);
 
     try {
-      transaction = TrinityLake.dropNamespace(storage, transaction, parseResult.namespaceName());
+      // cascade is false by default to keep consistent with Iceberg's HiveCatalog
+      transaction = TrinityLake.dropNamespace(storage, transaction, parseResult.namespaceName(), false);
     } catch (ObjectNotFoundException e) {
       LOG.warn("Detected dropping non-existent namespace {}", namespace);
       return false;

--- a/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
+++ b/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
@@ -302,7 +302,8 @@ public class TrinityLakeIcebergCatalog implements Catalog, SupportsNamespaces {
 
     try {
       // cascade is false by default to keep consistent with Iceberg's HiveCatalog
-      transaction = TrinityLake.dropNamespace(storage, transaction, parseResult.namespaceName(), false);
+      transaction =
+          TrinityLake.dropNamespace(storage, transaction, parseResult.namespaceName(), false);
     } catch (ObjectNotFoundException e) {
       LOG.warn("Detected dropping non-existent namespace {}", namespace);
       return false;

--- a/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
+++ b/core/src/main/java/io/trinitylake/iceberg/TrinityLakeIcebergCatalog.java
@@ -14,6 +14,7 @@
 package io.trinitylake.iceberg;
 
 import com.google.protobuf.Descriptors;
+import io.trinitylake.DropNamespaceBehavior;
 import io.trinitylake.ObjectDefinitions;
 import io.trinitylake.RunningTransaction;
 import io.trinitylake.TransactionOptions;
@@ -301,9 +302,9 @@ public class TrinityLakeIcebergCatalog implements Catalog, SupportsNamespaces {
     RunningTransaction transaction = beginOrLoadTransaction(parseResult);
 
     try {
-      // cascade is false by default to keep consistent with Iceberg's HiveCatalog
       transaction =
-          TrinityLake.dropNamespace(storage, transaction, parseResult.namespaceName(), false);
+          TrinityLake.dropNamespace(
+              storage, transaction, parseResult.namespaceName(), DropNamespaceBehavior.RESTRICT);
     } catch (ObjectNotFoundException e) {
       LOG.warn("Detected dropping non-existent namespace {}", namespace);
       return false;

--- a/core/src/test/java/io/trinitylake/TrinityLakeTests.java
+++ b/core/src/test/java/io/trinitylake/TrinityLakeTests.java
@@ -125,11 +125,27 @@ public abstract class TrinityLakeTests {
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
-    transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE);
+    transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE, false);
     TrinityLake.commitTransaction(storage, transaction);
     transaction = TrinityLake.beginTransaction(storage);
 
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isFalse();
+  }
+
+  @Test
+  public void testDropNamespaceCascade() {
+    LakehouseStorage storage = storage();
+    createNamespaceAndTables();
+
+    RunningTransaction transaction = TrinityLake.beginTransaction(storage);
+    assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
+    transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE, true);
+    TrinityLake.commitTransaction(storage, transaction);
+    transaction = TrinityLake.beginTransaction(storage);
+
+    assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isFalse();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isFalse();
   }
 
   @Test
@@ -345,6 +361,14 @@ public abstract class TrinityLakeTests {
     LakehouseStorage storage = storage();
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     transaction = TrinityLake.createNamespace(storage, transaction, NAMESPACE, NAMESPACE_DEF);
+    TrinityLake.commitTransaction(storage, transaction);
+  }
+
+  protected void createNamespaceAndTables() {
+    LakehouseStorage storage = storage();
+    RunningTransaction transaction = TrinityLake.beginTransaction(storage);
+    transaction = TrinityLake.createNamespace(storage, transaction, NAMESPACE, NAMESPACE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
     TrinityLake.commitTransaction(storage, transaction);
   }
 }

--- a/core/src/test/java/io/trinitylake/TrinityLakeTests.java
+++ b/core/src/test/java/io/trinitylake/TrinityLakeTests.java
@@ -137,7 +137,8 @@ public abstract class TrinityLakeTests {
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
-    transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE, false);
+    transaction =
+        TrinityLake.dropNamespace(storage, transaction, NAMESPACE, DropNamespaceBehavior.RESTRICT);
     TrinityLake.commitTransaction(storage, transaction);
     transaction = TrinityLake.beginTransaction(storage);
 
@@ -153,7 +154,8 @@ public abstract class TrinityLakeTests {
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
     assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
     assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE2)).isTrue();
-    transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE, true);
+    transaction =
+        TrinityLake.dropNamespace(storage, transaction, NAMESPACE, DropNamespaceBehavior.CASCADE);
     TrinityLake.commitTransaction(storage, transaction);
     transaction = TrinityLake.beginTransaction(storage);
 
@@ -171,7 +173,10 @@ public abstract class TrinityLakeTests {
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
     assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
     assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE2)).isTrue();
-    assertThatThrownBy(() -> TrinityLake.dropNamespace(storage, transaction, NAMESPACE, false))
+    assertThatThrownBy(
+            () ->
+                TrinityLake.dropNamespace(
+                    storage, transaction, NAMESPACE, DropNamespaceBehavior.RESTRICT))
         .isInstanceOf(NonEmptyNamespaceException.class)
         .hasMessageContaining(String.format("Namespace %s is not empty", NAMESPACE));
   }

--- a/core/src/test/java/io/trinitylake/TrinityLakeTests.java
+++ b/core/src/test/java/io/trinitylake/TrinityLakeTests.java
@@ -16,6 +16,7 @@ package io.trinitylake;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.trinitylake.exception.NonEmptyNamespaceException;
 import io.trinitylake.exception.ObjectAlreadyExistsException;
 import io.trinitylake.exception.ObjectNotFoundException;
 import io.trinitylake.models.Column;
@@ -43,7 +44,7 @@ public abstract class TrinityLakeTests {
   protected static final NamespaceDef NAMESPACE_DEF =
       ObjectDefinitions.newNamespaceDefBuilder().putProperties("k1", "v1").build();
 
-  protected static final TableDef TABLE_DEF =
+  protected static final TableDef TABLE1_DEF =
       ObjectDefinitions.newTableDefBuilder()
           .setSchema(
               Schema.newBuilder()
@@ -52,7 +53,18 @@ public abstract class TrinityLakeTests {
           .putProperties("k1", "v1")
           .build();
 
-  protected static final String TABLE = "tbl1";
+  protected static final String TABLE1 = "tbl1";
+
+  protected static final TableDef TABLE2_DEF =
+      ObjectDefinitions.newTableDefBuilder()
+          .setSchema(
+              Schema.newBuilder()
+                  .addColumns(Column.newBuilder().setName("c2").setType(DataType.INT8).build())
+                  .build())
+          .putProperties("k2", "v2")
+          .build();
+
+  protected static final String TABLE2 = "tbl2";
 
   protected static final ViewDef VIEW_DEF =
       ObjectDefinitions.newViewDefBuilder()
@@ -64,7 +76,7 @@ public abstract class TrinityLakeTests {
                   .setDialect("spark-sql")
                   .build())
           .addReferencedObjectFullNames(
-              FullName.newBuilder().setNamespaceName(NAMESPACE).setName(TABLE).build())
+              FullName.newBuilder().setNamespaceName(NAMESPACE).setName(TABLE1).build())
           .putProperties("k1", "v1")
           .build();
 
@@ -139,13 +151,29 @@ public abstract class TrinityLakeTests {
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE2)).isTrue();
     transaction = TrinityLake.dropNamespace(storage, transaction, NAMESPACE, true);
     TrinityLake.commitTransaction(storage, transaction);
     transaction = TrinityLake.beginTransaction(storage);
 
     assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isFalse();
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isFalse();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isFalse();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE2)).isFalse();
+  }
+
+  @Test
+  public void testDropNonEmptyNamespace() {
+    LakehouseStorage storage = storage();
+    createNamespaceAndTables();
+
+    RunningTransaction transaction = TrinityLake.beginTransaction(storage);
+    assertThat(TrinityLake.namespaceExists(storage, transaction, NAMESPACE)).isTrue();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE2)).isTrue();
+    assertThatThrownBy(() -> TrinityLake.dropNamespace(storage, transaction, NAMESPACE, false))
+        .isInstanceOf(NonEmptyNamespaceException.class)
+        .hasMessageContaining(String.format("Namespace %s is not empty", NAMESPACE));
   }
 
   @Test
@@ -187,16 +215,16 @@ public abstract class TrinityLakeTests {
     createNamespaceAndCommit();
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
-    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF);
     TrinityLake.commitTransaction(storage, transaction);
 
     TreeRoot root = TreeOperations.findLatestRoot(storage);
     assertTreeRoot(2);
-    String t1Key = ObjectKeys.tableKey(NAMESPACE, TABLE, LAKEHOUSE_DEF);
+    String t1Key = ObjectKeys.tableKey(NAMESPACE, TABLE1, LAKEHOUSE_DEF);
     Optional<String> t1Path = TreeOperations.searchValue(storage, root, t1Key);
     assertThat(t1Path.isPresent()).isTrue();
     TableDef readDef = ObjectDefinitions.readTableDef(storage, t1Path.get());
-    assertThat(readDef).isEqualTo(TABLE_DEF);
+    assertThat(readDef).isEqualTo(TABLE1_DEF);
   }
 
   @Test
@@ -205,13 +233,13 @@ public abstract class TrinityLakeTests {
     createNamespaceAndCommit();
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
-    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF);
     TrinityLake.commitTransaction(storage, transaction);
 
     transaction = TrinityLake.beginTransaction(storage);
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
-    TableDef t1DefDescribe = TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE);
-    assertThat(t1DefDescribe).isEqualTo(TABLE_DEF);
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    TableDef t1DefDescribe = TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE1);
+    assertThat(t1DefDescribe).isEqualTo(TABLE1_DEF);
   }
 
   @Test
@@ -220,13 +248,13 @@ public abstract class TrinityLakeTests {
     createNamespaceAndCommit();
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
-    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF);
     TrinityLake.commitTransaction(storage, transaction);
 
     transaction = TrinityLake.beginTransaction(storage);
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
-    TableDef t1DefDescribe = TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE);
-    assertThat(t1DefDescribe).isEqualTo(TABLE_DEF);
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    TableDef t1DefDescribe = TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE1);
+    assertThat(t1DefDescribe).isEqualTo(TABLE1_DEF);
 
     TableDef t1DefAlter =
         ObjectDefinitions.newTableDefBuilder()
@@ -237,12 +265,13 @@ public abstract class TrinityLakeTests {
                     .build())
             .putProperties("k1", "v2")
             .build();
-    transaction = TrinityLake.alterTable(storage, transaction, NAMESPACE, TABLE, t1DefAlter);
+    transaction = TrinityLake.alterTable(storage, transaction, NAMESPACE, TABLE1, t1DefAlter);
     TrinityLake.commitTransaction(storage, transaction);
 
     transaction = TrinityLake.beginTransaction(storage);
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
-    TableDef t1DefAlterDescribe = TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE);
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    TableDef t1DefAlterDescribe =
+        TrinityLake.describeTable(storage, transaction, NAMESPACE, TABLE1);
     assertThat(t1DefAlterDescribe).isEqualTo(t1DefAlter);
   }
 
@@ -252,16 +281,16 @@ public abstract class TrinityLakeTests {
     createNamespaceAndCommit();
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
-    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF);
     TrinityLake.commitTransaction(storage, transaction);
 
     transaction = TrinityLake.beginTransaction(storage);
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isTrue();
-    transaction = TrinityLake.dropTable(storage, transaction, NAMESPACE, TABLE);
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isTrue();
+    transaction = TrinityLake.dropTable(storage, transaction, NAMESPACE, TABLE1);
     TrinityLake.commitTransaction(storage, transaction);
 
     transaction = TrinityLake.beginTransaction(storage);
-    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE)).isFalse();
+    assertThat(TrinityLake.tableExists(storage, transaction, NAMESPACE, TABLE1)).isFalse();
   }
 
   @Test
@@ -270,7 +299,7 @@ public abstract class TrinityLakeTests {
 
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     assertThatThrownBy(
-            () -> TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF))
+            () -> TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF))
         .isInstanceOf(ObjectNotFoundException.class);
   }
 
@@ -368,7 +397,8 @@ public abstract class TrinityLakeTests {
     LakehouseStorage storage = storage();
     RunningTransaction transaction = TrinityLake.beginTransaction(storage);
     transaction = TrinityLake.createNamespace(storage, transaction, NAMESPACE, NAMESPACE_DEF);
-    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE, TABLE_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE1, TABLE1_DEF);
+    transaction = TrinityLake.createTable(storage, transaction, NAMESPACE, TABLE2, TABLE2_DEF);
     TrinityLake.commitTransaction(storage, transaction);
   }
 }

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trinitylake.spark;
 
+import io.trinitylake.DropNamespaceBehavior;
 import io.trinitylake.ObjectDefinitions;
 import io.trinitylake.RunningTransaction;
 import io.trinitylake.TrinityLake;
@@ -146,7 +147,12 @@ public class TrinityLakeSparkCatalog implements StagingTableCatalog, SupportsNam
     RunningTransaction transaction = currentTransaction();
 
     try {
-      transaction = TrinityLake.dropNamespace(storage, transaction, namespaceName, cascade);
+      transaction =
+          TrinityLake.dropNamespace(
+              storage,
+              transaction,
+              namespaceName,
+              cascade ? DropNamespaceBehavior.CASCADE : DropNamespaceBehavior.RESTRICT);
     } catch (ObjectNotFoundException e) {
       throw new NoSuchNamespaceException(namespace);
     } catch (NonEmptyNamespaceException e) {

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
@@ -30,7 +30,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;

--- a/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/io/trinitylake/spark/TrinityLakeSparkCatalog.java
@@ -140,22 +140,14 @@ public class TrinityLakeSparkCatalog implements StagingTableCatalog, SupportsNam
 
   @Override
   public boolean dropNamespace(String[] namespace, boolean cascade)
-      throws NoSuchNamespaceException, NonEmptyNamespaceException {
+      throws NoSuchNamespaceException {
     String namespaceName = SparkToTrinityLake.namespaceName(namespace);
     RunningTransaction transaction = currentTransaction();
 
     try {
-      transaction = TrinityLake.dropNamespace(storage, transaction, namespaceName);
+      transaction = TrinityLake.dropNamespace(storage, transaction, namespaceName, cascade);
     } catch (ObjectNotFoundException e) {
       throw new NoSuchNamespaceException(namespace);
-    }
-
-    // TODO: move this to the core library
-    if (cascade) {
-      List<String> tableNames = TrinityLake.showTables(storage, transaction, namespaceName);
-      for (String tableName : tableNames) {
-        transaction = TrinityLake.dropTable(storage, transaction, namespaceName, tableName);
-      }
     }
 
     TrinityLake.commitTransaction(storage, transaction);


### PR DESCRIPTION
GH issue: #96 

- Moved drop namespace cascade behavior from `TrinityLakeSparkCatalog` to `core/../TrinityLake` 
- Added `RESTRICT` behavior to fail `dropNamespace` when namespace is not empty
- Added `DropNamespaceBehavior` enum to exhaust supported drop namespace actions
